### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dylarcher/helper-utils/security/code-scanning/3](https://github.com/dylarcher/helper-utils/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. For this workflow:
1. The `build` job only needs read access to the repository contents to run tests.
2. The `publish-npm` job also only needs read access to the repository contents, as the npm publishing process uses the `NODE_AUTH_TOKEN` secret and does not require write access to the repository.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. In this case, adding it at the root level is more concise and ensures consistency across jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
